### PR TITLE
Fix missing content style

### DIFF
--- a/assets/styles/angled-edges.scss
+++ b/assets/styles/angled-edges.scss
@@ -83,6 +83,7 @@
   @if $fallback {
 
     &::before, &::after {
+      content: "";
       position: absolute;
       left: 0;
       z-index: 10;


### PR DESCRIPTION
fallback code is missing the content style in the `&::before, &::after`