### PR TITLE
Test for invalid angle before converting

### DIFF
--- a/assets/styles/angled-edges.scss
+++ b/assets/styles/angled-edges.scss
@@ -12,12 +12,12 @@
   overflow: hidden;
 
   // Converts degrees to VW, 100vw = 45deg using this technique
-  @if $angle < 46 {
-    $angle: convertDegToVW($angle);
-  }
   @if $angle > 45 {
     $angle: 0;
     @error 'Invalid angle, it must be between 1-45';
+  }
+  @if $angle < 46 {
+    $angle: convertDegToVW($angle);
   }
 
   @if $angle-position-bottom-x == '' {


### PR DESCRIPTION
Currently, if you specify an angle > 20 it will error as the angle is converted before it's tested for validity.